### PR TITLE
Add local editing server with admin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# upgraded-octo-enigma
+# RiotLegion Site
+
+This repo contains the static files for the RiotLegion website. A simple admin panel (`rladmin1.html`) can be used when running the local Node server to append content to each page. Edits are stored in the `edits/` directory so they can be committed to Git.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+   The site will be available at [http://localhost:8967](http://localhost:8967).
+
+Any content added through `rladmin1.html` is saved as HTML snippets in the `edits/` folder and will appear on the relevant pages.

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,70 @@
+// Admin panel functionality for local server edits
+
+// ensure default password exists
+if (!localStorage.getItem('adminPassword')) {
+  localStorage.setItem('adminPassword', 'password1');
+}
+
+function byId(id) {
+  return document.getElementById(id);
+}
+
+function showPanel() {
+  byId('login').style.display = 'none';
+  byId('adminPanel').style.display = 'block';
+}
+
+async function loadSnippet(page) {
+  const r = await fetch('/api/edits/' + page);
+  return r.text();
+}
+
+async function saveSnippet(page, content) {
+  await fetch('/api/edits/' + page, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({content})
+  });
+}
+
+async function deleteSnippet(page) {
+  await fetch('/api/edits/' + page, {method: 'DELETE'});
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  byId('loginButton').addEventListener('click', () => {
+    const stored = localStorage.getItem('adminPassword');
+    const entered = byId('passwordInput').value;
+    if (entered === stored) {
+      showPanel();
+    } else {
+      byId('loginError').textContent = 'Incorrect password';
+    }
+  });
+
+  byId('loadContent').addEventListener('click', async () => {
+    const page = byId('pageSelect').value;
+    byId('editor').value = await loadSnippet(page);
+  });
+
+  byId('saveContent').addEventListener('click', async () => {
+    const page = byId('pageSelect').value;
+    await saveSnippet(page, byId('editor').value);
+    alert('Saved');
+  });
+
+  byId('deleteContent').addEventListener('click', async () => {
+    const page = byId('pageSelect').value;
+    await deleteSnippet(page);
+    byId('editor').value = '';
+  });
+
+  byId('changePassword').addEventListener('click', () => {
+    const newPass = byId('newPassword').value.trim();
+    if (newPass) {
+      localStorage.setItem('adminPassword', newPass);
+      byId('passwordMessage').textContent = 'Password updated';
+      byId('newPassword').value = '';
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "riotlegion-site",
+  "version": "1.0.0",
+  "description": "Local server for RiotLegion site admin editing",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/rladmin1.html
+++ b/rladmin1.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="styles.css">
+  <title>Admin Panel</title>
+</head>
+<body>
+  <header>
+    <nav>
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="music.html">Music</a></li>
+        <li><a href="merch.html">Merch</a></li>
+        <li><a href="blog.html">Blog</a></li>
+        <li><a href="contact.html">Contact</a></li>
+        <li><a href="forum.html">Forum</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <div id="login">
+      <h2>Admin Login</h2>
+      <input type="password" id="passwordInput" placeholder="Password">
+      <button id="loginButton">Login</button>
+      <p id="loginError"></p>
+    </div>
+    <div id="adminPanel" style="display:none;">
+      <h1>Site Editor</h1>
+      <label for="pageSelect">Select page:</label>
+      <select id="pageSelect">
+        <option value="index.html">Home</option>
+        <option value="about.html">About</option>
+        <option value="music.html">Music</option>
+        <option value="merch.html">Merch</option>
+        <option value="blog.html">Blog</option>
+        <option value="contact.html">Contact</option>
+        <option value="forum.html">Forum</option>
+      </select>
+      <button id="loadContent">Load Saved Content</button>
+      <textarea id="editor" rows="10" cols="50"></textarea>
+      <div>
+        <button id="saveContent">Save</button>
+        <button id="deleteContent">Delete</button>
+      </div>
+      <h2>Change Password</h2>
+      <input type="password" id="newPassword" placeholder="New Password">
+      <button id="changePassword">Change Password</button>
+      <p id="passwordMessage"></p>
+    </div>
+  </main>
+  <script src="admin.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -31,6 +31,21 @@ const quotes = [
 setInterval(changeQuote, 5000);
 changeQuote();
 
+// load saved edits for the current page from server
+async function applyEdits(url) {
+  const page = url.split('/').pop();
+  const r = await fetch('/api/edits/' + page);
+  const saved = await r.text();
+  if (saved) {
+    const container = document.getElementById('content') || document.querySelector('main');
+    if (container) {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = saved;
+      container.appendChild(wrapper);
+    }
+  }
+}
+
 // basic PJAX navigation to keep the player alive
 function loadContent(url, addHistory = true) {
   fetch(url)
@@ -44,6 +59,7 @@ function loadContent(url, addHistory = true) {
       if (addHistory) {
         history.pushState({}, '', url);
       }
+      applyEdits(url);
     });
 }
 
@@ -60,4 +76,7 @@ window.addEventListener('popstate', () => {
   loadContent(location.pathname, false);
 });
 
-document.addEventListener('DOMContentLoaded', setupNavigation);
+document.addEventListener('DOMContentLoaded', () => {
+  setupNavigation();
+  applyEdits(location.pathname.split('/').pop() || 'index.html');
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = 8967;
+const EDIT_DIR = path.join(__dirname, 'edits');
+
+if (!fs.existsSync(EDIT_DIR)) {
+  fs.mkdirSync(EDIT_DIR);
+}
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+// Get saved snippet for a page
+app.get('/api/edits/:page', (req, res) => {
+  const file = path.join(EDIT_DIR, req.params.page + '.html');
+  if (fs.existsSync(file)) {
+    res.type('text/html').send(fs.readFileSync(file, 'utf8'));
+  } else {
+    res.type('text/html').send('');
+  }
+});
+
+// Save snippet for a page
+app.post('/api/edits/:page', (req, res) => {
+  const file = path.join(EDIT_DIR, req.params.page + '.html');
+  fs.writeFileSync(file, req.body.content || '');
+  res.json({status: 'saved'});
+});
+
+// Delete snippet for a page
+app.delete('/api/edits/:page', (req, res) => {
+  const file = path.join(EDIT_DIR, req.params.page + '.html');
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+  res.json({status: 'deleted'});
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node-based local server for saving page edits
- create package.json with express dependency
- update admin panel logic to load/save snippets via server
- fetch edits from server in main site script
- document local usage in README
- keep an `edits/` directory for saved snippets

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68432b82c69483299b12f076804c700c